### PR TITLE
Create makefile-test.linux

### DIFF
--- a/src/makefile-test.linux
+++ b/src/makefile-test.linux
@@ -15,10 +15,10 @@ LIBS = $(addprefix -L,$(BOOST_LIB_PATH))
 
 LIBS += \
  -Wl,-Bstatic \
-   -l boost_system \
-   -l boost_filesystem \
-   -l boost_program_options \
-   -l boost_thread 
+   -L boost_system \
+   -L boost_filesystem \
+   -L boost_program_options \
+   -L boost_thread 
 
 LIBS+= \
  -Wl,-Bdynamic \


### PR DESCRIPTION
Fixes:

[David@localhost src]$ make -f makefile-test.linux
g++  -o xtrabytes-test leveldb/libleveldb.a obj/util.o obj/crypto.o obj/error.o obj/redfat.o obj/test/test.o  -Wl,-Bstatic -l  boost_system -l boost_filesystem -l boost_program_options -l boost_thread  -Wl,-Bdynamic -l ssl -l crypto -l pthread /home/David/XtraBYtes/work/core-master/src/leveldb/libleveldb.a /home/David/XtraBYtes/work/core-master/src/leveldb/libmemenv.a
/usr/bin/ld: cannot find -lboost_system
/usr/bin/ld: cannot find -lboost_filesystem
/usr/bin/ld: cannot find -lboost_program_options
/usr/bin/ld: cannot find -lboost_thread
collect2: error: ld returned 1 exit status
make: *** [xtrabytes-test] Error 1